### PR TITLE
Z axis fix

### DIFF
--- a/main/src/plugins/visualisation/visualisation_agent.cpp
+++ b/main/src/plugins/visualisation/visualisation_agent.cpp
@@ -178,7 +178,7 @@ void VisualisationAgent::glut_thread_callback()
     glutInit(&argc, NULL);
   }
   glutInitWindowSize(m_resolution.x, m_resolution.y);
-  glutInitDisplayMode(GLUT_RGB | GLUT_DOUBLE);
+  glutInitDisplayMode(GLUT_RGB | GLUT_DOUBLE | GLUT_DEPTH);
   m_window_handle = glutCreateWindow(m_window_name.c_str());
 
   glViewport(0, 0, m_resolution.x, m_resolution.y);


### PR DESCRIPTION
Ahoj, toto by malo zapnúť správne prekrývanie agentov podľa ich Z súradnice.
Kladná hodnota ich dá bližšie ku kamere. Pri záporej si treba zase uvedomiť, že tá štvorcová mriežka je kreslená s nulou. Takže prekryje všetko, čo je pod ňou pokiaľ ju nevypneš v konfigurácii vizualizácie.